### PR TITLE
add .tgz support

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -74,7 +74,7 @@ of permissions within the archive.
 
 Eget supports the following filetypes for assets:
 
-* `.tar.gz`: tar archive with gzip compression.
+* `.tar.gz`/`.tgz`: tar archive with gzip compression.
 * `.tar.bz2`: tar archive with bzip2 compression.
 * `.tar.xz`: tar archive with xz compression.
 * `.tar`: tar archive with no compression.

--- a/extract.go
+++ b/extract.go
@@ -77,12 +77,7 @@ func NewExtractor(filename string, tool string, chooser Chooser) Extractor {
 	}
 
 	switch {
-	case strings.HasSuffix(filename, ".tar.gz"):
-		return &TarExtractor{
-			File:       chooser,
-			Decompress: gunzipper,
-		}
-	case strings.HasSuffix(filename, ".tgz"):
+	case strings.HasSuffix(filename, ".tar.gz"), strings.HasSuffix(filename, ".tgz"):
 		return &TarExtractor{
 			File:       chooser,
 			Decompress: gunzipper,

--- a/extract.go
+++ b/extract.go
@@ -82,6 +82,11 @@ func NewExtractor(filename string, tool string, chooser Chooser) Extractor {
 			File:       chooser,
 			Decompress: gunzipper,
 		}
+	case strings.HasSuffix(filename, ".tgz"):
+		return &TarExtractor{
+			File:       chooser,
+			Decompress: gunzipper,
+		}
 	case strings.HasSuffix(filename, ".tar.bz2"):
 		return &TarExtractor{
 			File:       chooser,


### PR DESCRIPTION
Added one more case to the extractor to match `.tgz` files since they should behave exactly like `.tar.gz`.

Ran into this issue when trying to download [dundee/gdu](https://github.com/dundee/gdu)