### PR TITLE
Enable building additional platforms

### DIFF
--- a/tools/build-all.go
+++ b/tools/build-all.go
@@ -27,7 +27,9 @@ func main() {
 		Arch string
 	}{
 		{"darwin", "amd64"},
-		// {"darwin", "arm64"},
+		{"darwin", "arm64"},
+		{"freebsd", "amd64"},
+		{"freebsd", "arm64"},
 		{"linux", "amd64"},
 		{"linux", "386"},
 		{"linux", "arm64"},


### PR DESCRIPTION
Enable darwin-arm64 for native Apple Silicon support, as well as FreeBSD
(a very common server platform).
