### PR TITLE
Add concurrent builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ GOVARS = -X main.Version=$(VERSION)
 build:
 	go build -trimpath -ldflags "-s -w $(GOVARS)" .
 
+build-dist:
+	go build -trimpath -ldflags "-s -w $(GOVARS)" -o dist/bin/eget-$(VERSION)-$(SYSTEM) .
+
 install:
 	go install -trimpath -ldflags "-s -w $(GOVARS)" .
 
@@ -22,18 +25,20 @@ test: eget
 	cd test; EGET_BIN= TEST_EGET=../eget go run test_eget.go
 
 eget.1: man/eget.md
-	pandoc man/eget.md -s -t man -o eget.1
+	pandoc man/eget.md -s -t man -o dist/eget.1
 
-package: build eget.1
-	mkdir eget-$(VERSION)-$(SYSTEM)
-	cp README.md eget-$(VERSION)-$(SYSTEM)
-	cp LICENSE eget-$(VERSION)-$(SYSTEM)
-	cp eget.1 eget-$(VERSION)-$(SYSTEM)
-	if [ ${GOOS} = "windows" ]; then\
-		cp eget.exe eget-$(VERSION)-$(SYSTEM);\
+package: build-dist eget.1
+	mkdir dist/eget-$(VERSION)-$(SYSTEM)
+	cp README.md dist/eget-$(VERSION)-$(SYSTEM)
+	cp LICENSE dist/eget-$(VERSION)-$(SYSTEM)
+	cp dist/eget.1 dist/eget-$(VERSION)-$(SYSTEM)
+	if [ "${GOOS}" = "windows" ]; then\
+		cp dist/bin/eget-$(VERSION)-$(SYSTEM) dist/eget-$(VERSION)-$(SYSTEM)/eget.exe;\
+		cd dist;\
 		zip -r -q -T eget-$(VERSION)-$(SYSTEM).zip eget-$(VERSION)-$(SYSTEM);\
 	else\
-		cp eget eget-$(VERSION)-$(SYSTEM);\
+		cp dist/bin/eget-$(VERSION)-$(SYSTEM) dist/eget-$(VERSION)-$(SYSTEM)/eget;\
+		cd dist;\
 		tar -czf eget-$(VERSION)-$(SYSTEM).tar.gz eget-$(VERSION)-$(SYSTEM);\
 	fi
 
@@ -41,8 +46,7 @@ version:
 	echo "package main\n\nvar Version = \"$(VERSION)+src\"" > version.go
 
 clean:
-	rm -f eget eget.exe eget.1 eget-*.tar.gz eget-*.zip
 	rm -f test/eget.1 test/fd test/micro test/nvim test/pandoc test/rg.exe
-	rm -rf eget-*/
+	rm -rf dist
 
 .PHONY: build clean install package version fmt vet test

--- a/tools/build-all.go
+++ b/tools/build-all.go
@@ -7,19 +7,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
+	"sync"
 )
 
-func pkg(tos, arch string) {
-	cmd := exec.Command("make", "package")
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env,
-		fmt.Sprintf("GOOS=%s", tos),
-		fmt.Sprintf("GOARCH=%s", arch),
-	)
-	err := cmd.Run()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-	}
+type Target struct {
+	OS   string
+	Arch string
 }
 
 func main() {
@@ -39,8 +33,33 @@ func main() {
 		{"windows", "386"},
 	}
 
-	for _, t := range targets {
-		fmt.Printf("%s-%s\n", t.OS, t.Arch)
-		pkg(t.OS, t.Arch)
+	compile := func(platform, architecture string, wg *sync.WaitGroup) {
+		defer wg.Done()
+
+		cmd := exec.Command("make", "package")
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env,
+			fmt.Sprintf("GOOS=%s", platform),
+			fmt.Sprintf("GOARCH=%s", architecture),
+			fmt.Sprintf("GOMAXPROCS=%d", runtime.NumCPU()),
+		)
+
+		err := cmd.Run()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+
+		fmt.Printf("finished building %s-%s\n", platform, architecture)
 	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(len(targets))
+
+	for _, t := range targets {
+		fmt.Printf("starting build for %s-%s\n", t.OS, t.Arch)
+		go compile(t.OS, t.Arch, &wg)
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
### Summary

This PR updates the `tools/build-all.go` utility to achieve significantly shorter overall build times on multi-core processors by using goroutines to allow concurrent builds.

Additionally, it updates the `Makefile` to send all outputs to the `dist` directory, keeping the generated files more organized.  It also adds a `build-dist` task, which is now used by the `package` task to output the compiled binary with a unique name (which was necessary due to the  concurrent build processes). The `clean` task was also updated accordingly.

### Benchmarks:

Benchmarks were run on a system with the following specs:

```
processor model name	: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
number of cpu cores	: 8
actual + virtual cores	: 16
```

#### Benchmark TLDR

- Concurrent builds complete in ~3 seconds
- Sequential builds complete in ~13 seconds

#### Benchmark Results

```bash
# concurrent builds
go run tools/build-all.go  27.36s user 7.27s system 1138% cpu 3.041 total
```

```bash
# sequential builds
go run tools/build-all.go  20.05s user 5.45s system 196% cpu 12.982 total
```