### PR TITLE
Exit with an error if scanf fails

### DIFF
--- a/eget.go
+++ b/eget.go
@@ -256,6 +256,11 @@ func userSelect(choices []interface{}) int {
 		if err == nil {
 			break
 		}
+
+		if errors.Is(err, io.EOF) {
+			fatal("Error reading selection")
+		}
+
 		fmt.Fprintf(os.Stderr, "Invalid selection: %v\n", err)
 	}
 	return choice


### PR DESCRIPTION
Exit if scanf returns an error, rather than going into an infinite loop if
we are unable to read from stdin.

Closes #58
