### PR TITLE
Add downloading of configuration-defined projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,24 +137,25 @@ Usage:
   eget [OPTIONS] TARGET
 
 Application Options:
-  -t, --tag=           tagged release to use instead of latest
-      --pre-release    include pre-releases when fetching the latest version
-      --source         download the source code for the target repo instead of a release
-      --to=            move to given location after extracting
-  -s, --system=        target system to download for (use "all" for all choices)
-  -f, --file=          glob to select files for extraction
-      --all            extract all candidate files
-  -q, --quiet          only print essential output
-  -d, --download-only  stop after downloading the asset (no extraction)
-      --upgrade-only   only download if release is more recent than current version
-  -a, --asset=         download a specific asset containing the given string; can be specified
-                       multiple times for additional filtering; use ^ for anti-match
-      --sha256         show the SHA-256 hash of the downloaded asset
-      --verify-sha256= verify the downloaded asset checksum against the one provided
-      --rate           show GitHub API rate limiting information
-  -r, --remove         remove the given file from $EGET_BIN or the current directory
-  -v, --version        show version information
-  -h, --help           show this help message
+  -t, --tag=            tagged release to use instead of latest
+      --pre-release     include pre-releases when fetching the latest version
+      --source          download the source code for the target repo instead of a release
+      --to=             move to given location after extracting
+  -s, --system=         target system to download for (use "all" for all choices)
+  -f, --file=           glob to select files for extraction
+      --all             extract all candidate files
+  -q, --quiet           only print essential output
+  -d, --download-only   stop after downloading the asset (no extraction)
+  -D  --download-config download all projects defined in the configuration file
+      --upgrade-only    only download if release is more recent than current version
+  -a, --asset=          download a specific asset containing the given string; can be specified
+                        multiple times for additional filtering; use ^ for anti-match
+      --sha256          show the SHA-256 hash of the downloaded asset
+      --verify-sha256=  verify the downloaded asset checksum against the one provided
+      --rate            show GitHub API rate limiting information
+  -r, --remove          remove the given file from $EGET_BIN or the current directory
+  -v, --version         show version information
+  -h, --help            show this help message
 ```
 
 # Configuration

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Application Options:
       --all             extract all candidate files
   -q, --quiet           only print essential output
   -d, --download-only   stop after downloading the asset (no extraction)
-  -D  --download-config download all projects defined in the configuration file
+  -D  --download-all    download all projects defined in the configuration file
       --upgrade-only    only download if release is more recent than current version
   -a, --asset=          download a specific asset containing the given string; can be specified
                         multiple times for additional filtering; use ^ for anti-match

--- a/eget.go
+++ b/eget.go
@@ -298,9 +298,14 @@ func bintime(bin string, to string) (t time.Time) {
 
 func downloadConfigRepositories(config *Config) error {
 	hasError := false
+	binary, err := os.Executable()
+
+	if err != nil {
+		binary = os.Args[0]
+	}
 
 	for name, _ := range config.Repositories {
-		cmd := exec.Command(os.Args[0], name)
+		cmd := exec.Command(binary, name)
 		stderr, _ := cmd.StderrPipe()
 		cmd.Start()
 

--- a/eget.go
+++ b/eget.go
@@ -297,6 +297,8 @@ func bintime(bin string, to string) (t time.Time) {
 
 func downloadConfigRepositories(config *Config) error {
 	hasError := false
+	errorList := []error{}
+
 	binary, err := os.Executable()
 
 	if err != nil {
@@ -310,15 +312,17 @@ func downloadConfigRepositories(config *Config) error {
 		err := cmd.Run()
 		if err != nil {
 			hasError = true
+			errorList = append(errorList, err)
 		}
 
 		if !hasError && cmd.ProcessState.ExitCode() != 0 {
 			hasError = true
+			errorList = append(errorList, err)
 		}
 	}
 
 	if hasError {
-		return errors.New("one or more repositories failed to download")
+		return fmt.Errorf("one or more errors occurred while downloading: %v", errorList)
 	}
 
 	return nil

--- a/eget.go
+++ b/eget.go
@@ -314,11 +314,6 @@ func downloadConfigRepositories(config *Config) error {
 			hasError = true
 			errorList = append(errorList, err)
 		}
-
-		if !hasError && cmd.ProcessState.ExitCode() != 0 {
-			hasError = true
-			errorList = append(errorList, err)
-		}
 	}
 
 	if hasError {

--- a/eget.go
+++ b/eget.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -306,17 +305,9 @@ func downloadConfigRepositories(config *Config) error {
 
 	for name, _ := range config.Repositories {
 		cmd := exec.Command(binary, name)
-		stderr, _ := cmd.StderrPipe()
+		cmd.Stderr = os.Stderr
+
 		cmd.Start()
-
-		scanner := bufio.NewScanner(stderr)
-		scanner.Split(bufio.ScanBytes)
-
-		for scanner.Scan() {
-			m := scanner.Text()
-			fmt.Print(m)
-		}
-
 		cmd.Wait()
 
 		if !hasError && cmd.ProcessState.ExitCode() != 0 {

--- a/eget.go
+++ b/eget.go
@@ -307,8 +307,10 @@ func downloadConfigRepositories(config *Config) error {
 		cmd := exec.Command(binary, name)
 		cmd.Stderr = os.Stderr
 
-		cmd.Start()
-		cmd.Wait()
+		err := cmd.Run()
+		if err != nil {
+			hasError = true
+		}
 
 		if !hasError && cmd.ProcessState.ExitCode() != 0 {
 			hasError = true

--- a/eget.go
+++ b/eget.go
@@ -369,7 +369,7 @@ func main() {
 		fatal(err)
 	}
 
-	if cli.ConfigDownload {
+	if cli.DownloadAll {
 		err = downloadConfigRepositories(config)
 
 		if err != nil {

--- a/flags.go
+++ b/flags.go
@@ -18,22 +18,22 @@ type Flags struct {
 }
 
 type CliFlags struct {
-	Tag            *string   `short:"t" long:"tag" description:"tagged release to use instead of latest"`
-	Prerelease     *bool     `long:"pre-release" description:"include pre-releases when fetching the latest version"`
-	Source         *bool     `long:"source" description:"download the source code for the target repo instead of a release"`
-	Output         *string   `long:"to" description:"move to given location after extracting"`
-	System         *string   `short:"s" long:"system" description:"target system to download for (use \"all\" for all choices)"`
-	ExtractFile    *string   `short:"f" long:"file" description:"glob to select files for extraction"`
-	All            *bool     `long:"all" description:"extract all candidate files"`
-	Quiet          *bool     `short:"q" long:"quiet" description:"only print essential output"`
-	DLOnly         *bool     `short:"d" long:"download-only" description:"stop after downloading the asset (no extraction)"`
-	UpgradeOnly    *bool     `long:"upgrade-only" description:"only download if release is more recent than current version"`
-	Asset          *[]string `short:"a" long:"asset" description:"download a specific asset containing the given string; can be specified multiple times for additional filtering; use ^ for anti-match"`
-	Hash           *bool     `long:"sha256" description:"show the SHA-256 hash of the downloaded asset"`
-	Verify         *string   `long:"verify-sha256" description:"verify the downloaded asset checksum against the one provided"`
-	Rate           bool      `long:"rate" description:"show GitHub API rate limiting information"`
-	Remove         *bool     `short:"r" long:"remove" description:"remove the given file from $EGET_BIN or the current directory"`
-	Version        bool      `short:"v" long:"version" description:"show version information"`
-	Help           bool      `short:"h" long:"help" description:"show this help message"`
-	ConfigDownload bool      `short:"D" long:"download-config" description:"download all projects defined in the config file"`
+	Tag         *string   `short:"t" long:"tag" description:"tagged release to use instead of latest"`
+	Prerelease  *bool     `long:"pre-release" description:"include pre-releases when fetching the latest version"`
+	Source      *bool     `long:"source" description:"download the source code for the target repo instead of a release"`
+	Output      *string   `long:"to" description:"move to given location after extracting"`
+	System      *string   `short:"s" long:"system" description:"target system to download for (use \"all\" for all choices)"`
+	ExtractFile *string   `short:"f" long:"file" description:"glob to select files for extraction"`
+	All         *bool     `long:"all" description:"extract all candidate files"`
+	Quiet       *bool     `short:"q" long:"quiet" description:"only print essential output"`
+	DLOnly      *bool     `short:"d" long:"download-only" description:"stop after downloading the asset (no extraction)"`
+	UpgradeOnly *bool     `long:"upgrade-only" description:"only download if release is more recent than current version"`
+	Asset       *[]string `short:"a" long:"asset" description:"download a specific asset containing the given string; can be specified multiple times for additional filtering; use ^ for anti-match"`
+	Hash        *bool     `long:"sha256" description:"show the SHA-256 hash of the downloaded asset"`
+	Verify      *string   `long:"verify-sha256" description:"verify the downloaded asset checksum against the one provided"`
+	Rate        bool      `long:"rate" description:"show GitHub API rate limiting information"`
+	Remove      *bool     `short:"r" long:"remove" description:"remove the given file from $EGET_BIN or the current directory"`
+	Version     bool      `short:"v" long:"version" description:"show version information"`
+	Help        bool      `short:"h" long:"help" description:"show this help message"`
+	DownloadAll bool      `short:"D" long:"download-all" description:"download all projects defined in the config file"`
 }

--- a/flags.go
+++ b/flags.go
@@ -18,21 +18,22 @@ type Flags struct {
 }
 
 type CliFlags struct {
-	Tag         *string   `short:"t" long:"tag" description:"tagged release to use instead of latest"`
-	Prerelease  *bool     `long:"pre-release" description:"include pre-releases when fetching the latest version"`
-	Source      *bool     `long:"source" description:"download the source code for the target repo instead of a release"`
-	Output      *string   `long:"to" description:"move to given location after extracting"`
-	System      *string   `short:"s" long:"system" description:"target system to download for (use \"all\" for all choices)"`
-	ExtractFile *string   `short:"f" long:"file" description:"glob to select files for extraction"`
-	All         *bool     `long:"all" description:"extract all candidate files"`
-	Quiet       *bool     `short:"q" long:"quiet" description:"only print essential output"`
-	DLOnly      *bool     `short:"d" long:"download-only" description:"stop after downloading the asset (no extraction)"`
-	UpgradeOnly *bool     `long:"upgrade-only" description:"only download if release is more recent than current version"`
-	Asset       *[]string `short:"a" long:"asset" description:"download a specific asset containing the given string; can be specified multiple times for additional filtering; use ^ for anti-match"`
-	Hash        *bool     `long:"sha256" description:"show the SHA-256 hash of the downloaded asset"`
-	Verify      *string   `long:"verify-sha256" description:"verify the downloaded asset checksum against the one provided"`
-	Rate        bool      `long:"rate" description:"show GitHub API rate limiting information"`
-	Remove      *bool     `short:"r" long:"remove" description:"remove the given file from $EGET_BIN or the current directory"`
-	Version     bool      `short:"v" long:"version" description:"show version information"`
-	Help        bool      `short:"h" long:"help" description:"show this help message"`
+	Tag            *string   `short:"t" long:"tag" description:"tagged release to use instead of latest"`
+	Prerelease     *bool     `long:"pre-release" description:"include pre-releases when fetching the latest version"`
+	Source         *bool     `long:"source" description:"download the source code for the target repo instead of a release"`
+	Output         *string   `long:"to" description:"move to given location after extracting"`
+	System         *string   `short:"s" long:"system" description:"target system to download for (use \"all\" for all choices)"`
+	ExtractFile    *string   `short:"f" long:"file" description:"glob to select files for extraction"`
+	All            *bool     `long:"all" description:"extract all candidate files"`
+	Quiet          *bool     `short:"q" long:"quiet" description:"only print essential output"`
+	DLOnly         *bool     `short:"d" long:"download-only" description:"stop after downloading the asset (no extraction)"`
+	UpgradeOnly    *bool     `long:"upgrade-only" description:"only download if release is more recent than current version"`
+	Asset          *[]string `short:"a" long:"asset" description:"download a specific asset containing the given string; can be specified multiple times for additional filtering; use ^ for anti-match"`
+	Hash           *bool     `long:"sha256" description:"show the SHA-256 hash of the downloaded asset"`
+	Verify         *string   `long:"verify-sha256" description:"verify the downloaded asset checksum against the one provided"`
+	Rate           bool      `long:"rate" description:"show GitHub API rate limiting information"`
+	Remove         *bool     `short:"r" long:"remove" description:"remove the given file from $EGET_BIN or the current directory"`
+	Version        bool      `short:"v" long:"version" description:"show version information"`
+	Help           bool      `short:"h" long:"help" description:"show this help message"`
+	ConfigDownload bool      `short:"D" long:"download-config" description:"download all projects defined in the config file"`
 }

--- a/man/eget.md
+++ b/man/eget.md
@@ -88,7 +88,7 @@ header: Eget Manual
 
 :    Stop after downloading the asset. This prevents Eget from performing extraction, allowing you to perform manual installation after the asset is downloaded.
 
-  `--download-config`
+  `--download-all`
 
 :   Download all projects defined in the configuration file.
 

--- a/man/eget.md
+++ b/man/eget.md
@@ -88,6 +88,10 @@ header: Eget Manual
 
 :    Stop after downloading the asset. This prevents Eget from performing extraction, allowing you to perform manual installation after the asset is downloaded.
 
+  `--download-config`
+
+:   Download all projects defined in the configuration file.
+
    --upgrade-only
 
 :    Only download the asset if the release is more recent than an existing asset with the same name in `$EGET_BIN`, or the current directory if `$EGET_BIN` is not defined.


### PR DESCRIPTION
## Overview
This PR adds an additional flag, `-D`/`--download-all`, which adds new functionality:

When specifying the `--download-all` flag, all projects/repositories defined in the configuration file are downloaded in the order they exist within the config file.

If this flag is specified, no other parameters are required.

## Implementation

This functionality was implemented by using `exec.Command()` to execute the currently running binary (which is an `eget` binary) sequentially for each of the configuration-defined repositories, and the output from the process is streamed in real time to the current `stdout` pipe by redirecting the `process.stderr` to the `os.stderr`.

This allows a complete implementation of batch downloading with a minimal amount of additional code, as it leverages `eget` functionality itself.

## Example Usage

Given the following configuration file:

```toml
[global]
    github_token = ""
    quiet = false
    show_hash = true
    upgrade_only = true
    target = "./test"

["zyedidia/micro"]
    name = "micro"
    upgrade_only = false
    show_hash = false
    asset_filters = [ "static.tar.gz" ]

["zyedidia/eget"]
    name = "eget"
    upgrade_only = false
    show_hash = false
    asset_filters = [ ".tar.gz" ]

["junegunn/fzf"]
    name = "fzf"
    upgrade_only = false
    quiet = false
```

The following output is displayed when running `eget --download-all`:
![image](https://user-images.githubusercontent.com/5508707/202898352-db09aa2b-b8d4-47ba-9900-f9a2de5c851f.png)

### Notes

Original Notes:
_I'm not 100% sure that `--download-config` is the best name for this flag, so please suggest alternatives if anything comes to mind.  I feel that it could be confusing if an end user thinks that the flag means a configuration file will be downloaded._

_Alternatives could be `--batch-download`, `--download-configured`, or something similar. Thoughts?_

**Updated Notes**: The flag has been renamed to `--download-all` per suggestion.
