### PR TITLE
feat(config): use system defaults for config fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ todo.txt
 eget.1
 /test/*
 !/test/test_eget.go
+!/test/eget.toml
 .eget.toml

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ eget:
 	go build -trimpath -ldflags "-s -w $(GOVARS)" .
 
 test: eget
-	cd test; EGET_BIN= TEST_EGET=../eget go run test_eget.go
+	cd test; EGET_CONFIG=eget.toml EGET_BIN= TEST_EGET=../eget go run test_eget.go
 
 eget.1: man/eget.md
 	pandoc man/eget.md -s -t man -o eget.1

--- a/README.md
+++ b/README.md
@@ -160,20 +160,20 @@ Application Options:
 
 # Configuration
 
-Eget can be configured using a TOML file located at `~/.eget.toml`. Alternatively,
-the configuration file can be located in the same directory as the Eget binary.
+Eget can be configured using a TOML file located at `~/.eget.toml` or it will fallback to the expected `XDG_CONFIG_HOME` directory of your os. Alternatively,
+the configuration file can be located in the same directory as the Eget binary or the path specified with the environment variable `EGET_CONFIG`.
 
 Both global settings can be configured, as well as setting on a per-repository basis.
 
 Sections can be named either `global` or `"owner/repo"`, where `owner` and `repo`
-are the owner and repository name of the target repository (not that the `owner/repo` 
+are the owner and repository name of the target repository (not that the `owner/repo`
 format is quoted).
 
-For example, the following configuration file will set the `--to` flag to `~/bin` for 
-all repositories, and will set the `--to` flag to `~/.local/bin` for the `zyedidia/micro` 
+For example, the following configuration file will set the `--to` flag to `~/bin` for
+all repositories, and will set the `--to` flag to `~/.local/bin` for the `zyedidia/micro`
 repository.
-  
-  ```toml
+
+```toml
 [global]
 target = "~/bin"
 
@@ -279,16 +279,16 @@ Eget should work out-of-the-box with many methods for releasing software, and
 does not require that you build your release process for Eget in particular.
 However, here are some rules that will guarantee compatibility with Eget.
 
-* Provide your pre-built binaries as GitHub release assets.
-* Format the system name as `OS_Arch` and include it in every pre-built binary
+- Provide your pre-built binaries as GitHub release assets.
+- Format the system name as `OS_Arch` and include it in every pre-built binary
   name. Supported OSes are `darwin`/`macos`, `windows`, `linux`, `netbsd`,
   `openbsd`, `freebsd`, `android`, `illumos`, `solaris`, `plan9`. Supported
   architectures are `amd64`, `i386`, `arm`, `arm64`, `riscv64`.
-* If desired, include `*.sha256` files for each asset, containing the SHA-256
+- If desired, include `*.sha256` files for each asset, containing the SHA-256
   checksum of each asset. These checksums will be automatically verified by
   Eget.
-* Include only a single executable or appimage per system in each release archive.
-* Use `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar`, or `.zip` for archives. You may
+- Include only a single executable or appimage per system in each release archive.
+- Use `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar`, or `.zip` for archives. You may
   also directly upload the executable without an archive, or a compressed
   executable ending in `.gz`, `.bz2`, or `.xz`.
 

--- a/config.go
+++ b/config.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/BurntSushi/toml"
 	"github.com/jessevdk/go-flags"
@@ -66,14 +68,55 @@ func LoadConfigurationFile(path string) (Config, error) {
 	return conf, err
 }
 
+func GetOSConfigPath(homePath string) string {
+	var configDir string
+
+	defaultConfig := map[string]string{
+		"windows": "LocalAppData",
+		"darwin":  "Library/Application Support",
+		"linux":   ".config",
+	}
+
+	goos := runtime.GOOS
+	switch goos {
+	case "windows":
+		configDir = os.Getenv("LOCALAPPDATA")
+	case "darwin", "linux":
+		configDir = os.Getenv("XDG_CONFIG_HOME")
+	case "default":
+		// exit with no path for unknown os
+		return ""
+	}
+
+	if configDir == "" {
+		configDir = filepath.Join(homePath, defaultConfig[goos])
+	}
+
+	return filepath.Join(configDir, "eget", "eget.toml")
+}
+
 func InitializeConfig() *Config {
+	var err error
+	var config Config
+
 	homePath, _ := os.UserHomeDir()
 	appName := "eget"
 
-	config, err := LoadConfigurationFile(homePath + "/." + appName + ".toml")
+	if configFilePath, ok := os.LookupEnv("EGET_CONFIG"); ok {
+		config, err = LoadConfigurationFile(configFilePath)
+	}
+
+	if err != nil {
+		config, err = LoadConfigurationFile(homePath + "/." + appName + ".toml")
+	}
 
 	if err != nil {
 		config, err = LoadConfigurationFile(appName + ".toml")
+	}
+
+	configFallBackPath := GetOSConfigPath(homePath)
+	if err != nil && configFallBackPath != "" {
+		config, err = LoadConfigurationFile(configFallBackPath)
 	}
 
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -104,9 +104,7 @@ func InitializeConfig() *Config {
 
 	if configFilePath, ok := os.LookupEnv("EGET_CONFIG"); ok {
 		config, err = LoadConfigurationFile(configFilePath)
-	}
-
-	if err != nil {
+	} else {
 		config, err = LoadConfigurationFile(homePath + "/." + appName + ".toml")
 	}
 

--- a/config.go
+++ b/config.go
@@ -73,19 +73,17 @@ func GetOSConfigPath(homePath string) string {
 
 	defaultConfig := map[string]string{
 		"windows": "LocalAppData",
-		"darwin":  "Library/Application Support",
-		"linux":   ".config",
+		"default": ".config",
 	}
 
-	goos := runtime.GOOS
-	switch goos {
+	var goos string
+	switch runtime.GOOS {
 	case "windows":
 		configDir = os.Getenv("LOCALAPPDATA")
-	case "darwin", "linux":
+		goos = "windows"
+	default:
 		configDir = os.Getenv("XDG_CONFIG_HOME")
-	case "default":
-		// exit with no path for unknown os
-		return ""
+		goos = "default"
 	}
 
 	if configDir == "" {


### PR DESCRIPTION
This PR updates the config search process with an expected system config path adhering to `XDG_CONFIG_HOME` as a final fallback or an initial look up attempt to read from `EGET_CONFIG` if specified.