### PR TITLE
feat(rate): also display reset time as duration from now when available

### DIFF
--- a/dl.go
+++ b/dl.go
@@ -83,7 +83,16 @@ func (r RateLimit) ResetTime() time.Time {
 }
 
 func (r RateLimit) String() string {
-	return fmt.Sprintf("Limit: %d, Remaining: %d, Reset: %v", r.Limit, r.Remaining, r.ResetTime())
+	now := time.Now()
+	rtime := r.ResetTime()
+	if rtime.Before(now) {
+		return fmt.Sprintf("Limit: %d, Remaining: %d, Reset: %v", r.Limit, r.Remaining, rtime)
+	} else {
+		return fmt.Sprintf(
+			"Limit: %d, Remaining: %d, Reset: %v (%v)",
+			r.Limit, r.Remaining, rtime, rtime.Sub(now).Round(time.Second),
+		)
+	}
 }
 
 func GetRateLimit() (RateLimit, error) {


### PR DESCRIPTION
While testing eget, I hit the rate limit (without token) of GitHub and thought it would be a nicer UX to not only show at which date the rate limit will be reset but also a duration to that date from now.

With this PR, `eget` shows the following message when the rate limit is exhausted:
```
$ eget --rate
Limit: 60, Remaining: 0, Reset: 2023-10-21 23:06:19 +0100 IST (20m42s)
```
And this message when it is not (e.g. using a token):
```
$ eget --rate
Limit: 5000, Remaining: 5000, Reset: 2023-10-21 23:57:48 +0100 IST
```