### PR TITLE
feat(cli): display target when no upgrade is available

### DIFF
--- a/eget.go
+++ b/eget.go
@@ -408,7 +408,7 @@ func main() {
 	assets, err := finder.Find()
 	if err != nil {
 		if errors.Is(err, ErrNoUpgrade) {
-			fmt.Fprintf(output, "%v\n", err)
+			fmt.Fprintf(output, "%s: %v\n", target, err)
 			os.Exit(0)
 		}
 		fatal(err)


### PR DESCRIPTION
Here is another small UX improvement.
When there is no upgrade available for a target, `eget` does not report which target it is.
While this is redundant for a single target, it becomes confusing when using the `-D, --download-all` option.

For a configuration file with multiple targets configured, without this PR:
```
$ eget --download-all
requested release is not more recent than current version
requested release is not more recent than current version
requested release is not more recent than current version
requested release is not more recent than current version
requested release is not more recent than current version
requested release is not more recent than current version
requested release is not more recent than current version
requested release is not more recent than current version
requested release is not more recent than current version
requested release is not more recent than current version
requested release is not more recent than current version
```

And with this PR applied:
```
$ eget --download-all
jqlang/jq: requested release is not more recent than current version
koalaman/shellcheck: requested release is not more recent than current version
hadolint/hadolint: requested release is not more recent than current version
zyedidia/eget: requested release is not more recent than current version
zyedidia/micro: requested release is not more recent than current version
golangci/golangci-lint: requested release is not more recent than current version
carvel-dev/ytt: requested release is not more recent than current version
go-task/task: requested release is not more recent than current version
goreleaser/goreleaser: requested release is not more recent than current version
mikefarah/yq: requested release is not more recent than current version
vectordotdev/vector: requested release is not more recent than current version
```