### PR TITLE
fix(config): expand home in GitHub token file read and use token for rate

### DIFF
--- a/config.go
+++ b/config.go
@@ -226,8 +226,8 @@ func update[T any](config T, cli *T) T {
 	return *cli
 }
 
-// Move the loaded configuration file options into the opts variable
-func SetOptionsFromConfig(config *Config, parser *flags.Parser, opts *Flags, cli CliFlags, projectName string) error {
+// Move the loaded configuration file global options into the opts variable
+func SetGlobalOptionsFromConfig(config *Config, parser *flags.Parser, opts *Flags, cli CliFlags) error {
 	if config.Global.GithubToken != "" && os.Getenv("EGET_GITHUB_TOKEN") == "" {
 		os.Setenv("EGET_GITHUB_TOKEN", config.Global.GithubToken)
 	}
@@ -251,7 +251,11 @@ func SetOptionsFromConfig(config *Config, parser *flags.Parser, opts *Flags, cli
 	opts.Verify = update("", cli.Verify)
 	opts.Remove = update(false, cli.Remove)
 	opts.DisableSSL = update(false, cli.DisableSSL)
+	return nil
+}
 
+// Move the loaded configuration file project options into the opts variable
+func SetProjectOptionsFromConfig(config *Config, parser *flags.Parser, opts *Flags, cli CliFlags, projectName string) error {
 	for name, repo := range config.Repositories {
 		if name == projectName {
 			opts.All = update(repo.All, cli.All)

--- a/dl.go
+++ b/dl.go
@@ -12,12 +12,17 @@ import (
 	"time"
 
 	pb "github.com/schollz/progressbar/v3"
+	"github.com/zyedidia/eget/home"
 )
 
 func tokenFrom(s string) (string, error) {
 	if strings.HasPrefix(s, "@") {
-		b, err := os.ReadFile(s[1:])
-		return string(b), err
+		f, err := home.Expand(s[1:])
+		if err != nil {
+			return "", err
+		}
+		b, err := os.ReadFile(f)
+		return strings.TrimRight(string(b), "\r\n"), nil
 	}
 	return s, nil
 }

--- a/eget.go
+++ b/eget.go
@@ -346,6 +346,16 @@ func main() {
 		os.Exit(0)
 	}
 
+	config, err := InitializeConfig()
+	if err != nil {
+		fatal(err)
+	}
+
+	err = SetGlobalOptionsFromConfig(config, flagparser, &opts, cli)
+	if err != nil {
+		fatal(err)
+	}
+
 	if cli.Rate {
 		rdat, err := GetRateLimit()
 		if err != nil {
@@ -361,12 +371,7 @@ func main() {
 		target = args[0]
 	}
 
-	config, err := InitializeConfig()
-	if err != nil {
-		fatal(err)
-	}
-
-	err = SetOptionsFromConfig(config, flagparser, &opts, cli, target)
+	err = SetProjectOptionsFromConfig(config, flagparser, &opts, cli, target)
 	if err != nil {
 		fatal(err)
 	}


### PR DESCRIPTION
This PR fixes three issues I found while testing the new GitHub token reading from files:
* The `~/` home directory shortcut was not expanded, for example in `@~/secrets/github-token`.
* When loading a GitHub token from file, the newline/carriage-return at the end of the file were also read into the token.
* When using the `--rate` option, the GitHub token stored in a config file was not used.

For the second point I used `strings.TrimRight()`, which strips _any_ of the `\r\n` runes. Therefore, the trimming works properly for all OS line-ending styles (Unix, Mac, Windows).

To fix the third point, I had to separate the loading of global options from project options into two different functions so the global options can be loaded earlier for the `--rate` option to have a populated GitHub token from a config file.