### PR TITLE
feat(download): report non-OK HTTP status codes when downloading

### DIFF
--- a/dl.go
+++ b/dl.go
@@ -150,6 +150,14 @@ func Download(url string, out io.Writer, getbar func(size int64) *pb.ProgressBar
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("download error: %d: %s", resp.StatusCode, body)
+	}
+
 	bar := getbar(resp.ContentLength)
 	_, err = io.Copy(io.MultiWriter(out, bar), resp.Body)
 	return err


### PR DESCRIPTION
When testing `eget` with private repositories (using a token for authentication), I realized the following error is returned:
```
$ ./eget hhromic/privaterepo
https://github.com/hhromic/privaterepo/releases/download/v1.0.0/privaterepo_1.0.0_linux_amd64.tar.gz
unexpected EOF
```

After further investigation, it turns out that GitHub requires the API for downloading private assets and direct asset download URLs do not work even when passing a valid token (I validated this with `curl` too). This produces an HTTP 404 error that the `Download()` function does not detect as an error and `eget` tries to extract the "not found" payload anyway.

I'm planning to implement support for private assets, but in the meantime this PR implements error handling for non-OK HTTP status codes when downloading so users get correct error messages for this or any future conditions. For example:
```
$ ./eget hhromic/privaterepo
https://github.com/hhromic/privaterepo/releases/download/v1.0.0/privaterepo_1.0.0_linux_amd64.tar.gz
download error: 404: Not Found (URL: https://github.com/hhromic/privaterepo/releases/download/v1.0.0/privaterepo_1.0.0_linux_amd64.tar.gz)
```