### PR TITLE
feat: add support for assets in private repositories

### DIFF
--- a/dl.go
+++ b/dl.go
@@ -50,7 +50,7 @@ func SetAuthHeader(req *http.Request) *http.Request {
 			fmt.Fprintln(os.Stderr, "error: cannot use GitHub token if SSL verification is disabled")
 			os.Exit(1)
 		}
-		req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 
 	return req

--- a/find.go
+++ b/find.go
@@ -10,15 +10,22 @@ import (
 	"time"
 )
 
-// A Finder returns a list of URLs making up a project's assets.
+// A Finder returns a list of assets for a project.
 type Finder interface {
-	Find() ([]string, error)
+	Find() ([]Asset, error)
+}
+
+// An Asset is the name (if any) and download URL for an asset of a project.
+type Asset struct {
+	Name        string
+	DownloadURL string
 }
 
 // A GithubRelease matches the Assets portion of Github's release API json.
 type GithubRelease struct {
 	Assets []struct {
-		DownloadURL string `json:"browser_download_url"`
+		Name string `json:"name"`
+		URL  string `json:"url"`
 	} `json:"assets"`
 
 	Prerelease bool      `json:"prerelease"`
@@ -58,7 +65,7 @@ type GithubAssetFinder struct {
 
 var ErrNoUpgrade = errors.New("requested release is not more recent than current version")
 
-func (f *GithubAssetFinder) Find() ([]string, error) {
+func (f *GithubAssetFinder) Find() ([]Asset, error) {
 	if f.Prerelease && f.Tag == "latest" {
 		tag, err := f.getLatestTag()
 		if err != nil {
@@ -109,15 +116,15 @@ func (f *GithubAssetFinder) Find() ([]string, error) {
 	}
 
 	// accumulate all assets from the json into a slice
-	assets := make([]string, 0, len(release.Assets))
+	assets := make([]Asset, 0, len(release.Assets))
 	for _, a := range release.Assets {
-		assets = append(assets, a.DownloadURL)
+		assets = append(assets, Asset{Name: a.Name, DownloadURL: a.URL})
 	}
 
 	return assets, nil
 }
 
-func (f *GithubAssetFinder) FindMatch() ([]string, error) {
+func (f *GithubAssetFinder) FindMatch() ([]Asset, error) {
 	tag := f.Tag[len("tags/"):]
 
 	for page := 1; ; page++ {
@@ -160,9 +167,9 @@ func (f *GithubAssetFinder) FindMatch() ([]string, error) {
 			}
 			if strings.Contains(r.Tag, tag) && !r.CreatedAt.Before(f.MinTime) {
 				// we have a winner
-				assets := make([]string, 0, len(r.Assets))
+				assets := make([]Asset, 0, len(r.Assets))
 				for _, a := range r.Assets {
-					assets = append(assets, a.DownloadURL)
+					assets = append(assets, Asset{Name: a.Name, DownloadURL: a.URL})
 				}
 				return assets, nil
 			}
@@ -207,8 +214,12 @@ type DirectAssetFinder struct {
 	URL string
 }
 
-func (f *DirectAssetFinder) Find() ([]string, error) {
-	return []string{f.URL}, nil
+func (f *DirectAssetFinder) Find() ([]Asset, error) {
+	asset := Asset{
+		Name:        f.URL,
+		DownloadURL: f.URL,
+	}
+	return []Asset{asset}, nil
 }
 
 type GithubSourceFinder struct {
@@ -217,6 +228,11 @@ type GithubSourceFinder struct {
 	Tag  string
 }
 
-func (f *GithubSourceFinder) Find() ([]string, error) {
-	return []string{fmt.Sprintf("https://github.com/%s/tarball/%s/%s.tar.gz", f.Repo, f.Tag, f.Tool)}, nil
+func (f *GithubSourceFinder) Find() ([]Asset, error) {
+	name := fmt.Sprintf("%s.tar.gz", f.Tool)
+	asset := Asset{
+		Name:        name,
+		DownloadURL: fmt.Sprintf("https://github.com/%s/tarball/%s/%s", f.Repo, f.Tag, name),
+	}
+	return []Asset{asset}, nil
 }

--- a/find.go
+++ b/find.go
@@ -69,7 +69,7 @@ func (f *GithubAssetFinder) Find() ([]string, error) {
 
 	// query github's API for this repo/tag pair.
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/%s", f.Repo, f.Tag)
-	resp, err := Get(url)
+	resp, err := Get(url, AcceptGitHubJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (f *GithubAssetFinder) FindMatch() ([]string, error) {
 
 	for page := 1; ; page++ {
 		url := fmt.Sprintf("https://api.github.com/repos/%s/releases?page=%d", f.Repo, page)
-		resp, err := Get(url)
+		resp, err := Get(url, AcceptGitHubJSON)
 		if err != nil {
 			return nil, err
 		}
@@ -179,7 +179,7 @@ func (f *GithubAssetFinder) FindMatch() ([]string, error) {
 // finds the latest pre-release and returns the tag
 func (f *GithubAssetFinder) getLatestTag() (string, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases", f.Repo)
-	resp, err := Get(url)
+	resp, err := Get(url, AcceptGitHubJSON)
 	if err != nil {
 		return "", fmt.Errorf("pre-release finder: %w", err)
 	}

--- a/verify.go
+++ b/verify.go
@@ -65,7 +65,7 @@ type Sha256AssetVerifier struct {
 }
 
 func (s256 *Sha256AssetVerifier) Verify(b []byte) error {
-	resp, err := Get(s256.AssetURL)
+	resp, err := Get(s256.AssetURL, AcceptBinary)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds support for downloading assets from private repositories in `eget`.

I had to do some code improvements to facilitate this feature, which I implemented in separate commits for an easier review:
* chore(http): send token using standard `Bearer` authorization scheme
  * the Bearer scheme also allows to use JSON web tokens (JWT)
  * ref: <https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api>
* chore(http): allow to provide `Accept` header in `Get()`
  * all binary downloads should use the `application/octet-stream` media type
  * all GitHub API calls should use the `application/vnd.github+json` media type
  * also refactor `GetRateLimit()` to use `Get()` instead of own HTTP request
  * ref: <https://docs.github.com/en/rest/overview/media-types>

The main changes to support assets in private repositories are in the third commit:
* feat: add support for assets in private repositories
  * download assets through the GitHub API instead of browser download links
  * allows to download from private repositories when combined with a GitHub token
  * added new Asset type with the Name (necessary for matching) and DownloadURL of an asset
  * ref: <https://docs.github.com/en/rest/releases/assets>

The key aspect is using `url` instead of `browser_download_url` in the assets JSON response from GitHub, which always works for both public and private repositories (when using a GitHub token). However, the asset URL uses asset IDs instead of asset filenames. Therefore, I also introduced an `Asset` type that contains both, the Name of the asset and the DownloadURL.

Then, the majority of the changes are refactoring functions to use `Asset` instances instead of a plain `string`. In this way, all functions remain with access to the actual asset name regardless of the URL and thus private assets work seamlessly.

I tested this with both public and private repository assets, and with and without using a GitHub token.
