### PR TITLE
gitea support

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/jessevdk/go-flags"
+
 	"github.com/zyedidia/eget/home"
 )
 
@@ -40,6 +41,8 @@ type ConfigRepository struct {
 	UpgradeOnly  bool     `toml:"upgrade_only"`
 	Verify       string   `toml:"verify_sha256"`
 	DisableSSL   bool     `toml:"disable_ssl"`
+	Host         string   `toml:"host"`
+	HostType     string   `toml:"host_type"`
 }
 
 type Config struct {
@@ -54,7 +57,6 @@ type Config struct {
 func LoadConfigurationFile(path string) (Config, error) {
 	var conf Config
 	meta, err := toml.DecodeFile(path, &conf)
-
 	if err != nil {
 		return conf, err
 	}
@@ -251,6 +253,8 @@ func SetGlobalOptionsFromConfig(config *Config, parser *flags.Parser, opts *Flag
 	opts.Verify = update("", cli.Verify)
 	opts.Remove = update(false, cli.Remove)
 	opts.DisableSSL = update(false, cli.DisableSSL)
+	opts.Host = update("", cli.Host)
+	opts.HostType = update("", cli.HostType)
 	return nil
 }
 
@@ -275,6 +279,8 @@ func SetProjectOptionsFromConfig(config *Config, parser *flags.Parser, opts *Fla
 			opts.UpgradeOnly = update(repo.UpgradeOnly, cli.UpgradeOnly)
 			opts.Verify = update(repo.Verify, cli.Verify)
 			opts.DisableSSL = update(repo.DisableSSL, cli.DisableSSL)
+			opts.Host = update(repo.Host, cli.Host)
+			opts.HostType = update(repo.HostType, cli.HostType)
 			break
 		}
 	}

--- a/dl.go
+++ b/dl.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	pb "github.com/schollz/progressbar/v3"
+
 	"github.com/zyedidia/eget/home"
 )
 
@@ -58,7 +59,6 @@ func SetAuthHeader(req *http.Request) *http.Request {
 
 func Get(url string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", url, nil)
-
 	if err != nil {
 		return nil, err
 	}

--- a/eget.go
+++ b/eget.go
@@ -361,8 +361,6 @@ func main() {
 		fatal(err)
 	}
 
-	fmt.Println(opts)
-
 	err = SetGlobalOptionsFromConfig(config, flagparser, &opts, cli)
 	if err != nil {
 		fatal(err)

--- a/find.go
+++ b/find.go
@@ -185,7 +185,6 @@ func (f *AssetFinder) FindMatch() ([]string, error) {
 }
 
 func (f *AssetFinder) getReleasesUrl() string {
-	fmt.Println(f.HostType)
 	switch f.HostType {
 	case Github:
 		return fmt.Sprintf("https://api.%s/repos/%s/releases", f.Host, f.Repo)

--- a/flags.go
+++ b/flags.go
@@ -16,26 +16,30 @@ type Flags struct {
 	Verify      string
 	Remove      bool
 	DisableSSL  bool
+	Host        string
+	HostType    string
 }
 
 type CliFlags struct {
-	Tag         *string   `short:"t" long:"tag" description:"tagged release to use instead of latest"`
-	Prerelease  *bool     `long:"pre-release" description:"include pre-releases when fetching the latest version"`
-	Source      *bool     `long:"source" description:"download the source code for the target repo instead of a release"`
-	Output      *string   `long:"to" description:"move to given location after extracting"`
-	System      *string   `short:"s" long:"system" description:"target system to download for (use \"all\" for all choices)"`
-	ExtractFile *string   `short:"f" long:"file" description:"glob to select files for extraction"`
-	All         *bool     `long:"all" description:"extract all candidate files"`
-	Quiet       *bool     `short:"q" long:"quiet" description:"only print essential output"`
+	Tag         *string   `short:"t" long:"tag"           description:"tagged release to use instead of latest"`
+	Prerelease  *bool     `          long:"pre-release"   description:"include pre-releases when fetching the latest version"`
+	Source      *bool     `          long:"source"        description:"download the source code for the target repo instead of a release"`
+	Output      *string   `          long:"to"            description:"move to given location after extracting"`
+	System      *string   `short:"s" long:"system"        description:"target system to download for (use 'all' for all choices)"`
+	ExtractFile *string   `short:"f" long:"file"          description:"glob to select files for extraction"`
+	All         *bool     `          long:"all"           description:"extract all candidate files"`
+	Quiet       *bool     `short:"q" long:"quiet"         description:"only print essential output"`
 	DLOnly      *bool     `short:"d" long:"download-only" description:"stop after downloading the asset (no extraction)"`
-	UpgradeOnly *bool     `long:"upgrade-only" description:"only download if release is more recent than current version"`
-	Asset       *[]string `short:"a" long:"asset" description:"download a specific asset containing the given string; can be specified multiple times for additional filtering; use ^ for anti-match"`
-	Hash        *bool     `long:"sha256" description:"show the SHA-256 hash of the downloaded asset"`
-	Verify      *string   `long:"verify-sha256" description:"verify the downloaded asset checksum against the one provided"`
-	Rate        bool      `long:"rate" description:"show GitHub API rate limiting information"`
-	Remove      *bool     `short:"r" long:"remove" description:"remove the given file from $EGET_BIN or the current directory"`
-	Version     bool      `short:"v" long:"version" description:"show version information"`
-	Help        bool      `short:"h" long:"help" description:"show this help message"`
-	DownloadAll bool      `short:"D" long:"download-all" description:"download all projects defined in the config file"`
-	DisableSSL  *bool     `short:"k" long:"disable-ssl" description:"disable SSL verification for download requests"`
+	UpgradeOnly *bool     `          long:"upgrade-only"  description:"only download if release is more recent than current version"`
+	Asset       *[]string `short:"a" long:"asset"         description:"download a specific asset containing the given string; can be specified multiple times for additional filtering; use ^ for anti-match"`
+	Hash        *bool     `          long:"sha256"        description:"show the SHA-256 hash of the downloaded asset"`
+	Verify      *string   `          long:"verify-sha256" description:"verify the downloaded asset checksum against the one provided"`
+	Rate        bool      `          long:"rate"          description:"show GitHub API rate limiting information"`
+	Remove      *bool     `short:"r" long:"remove"        description:"remove the given file from $EGET_BIN or the current directory"`
+	Version     bool      `short:"v" long:"version"       description:"show version information"`
+	Help        bool      `short:"h" long:"help"          description:"show this help message"`
+	DownloadAll bool      `short:"D" long:"download-all"  description:"download all projects defined in the config file"`
+	DisableSSL  *bool     `short:"k" long:"disable-ssl"   description:"disable SSL verification for download requests"`
+	Host        *string   `short:"H" long:"host"          description:"host to download from"`
+	HostType    *string   `short:"T" long:"host-type"     description:"type of host to download from"`
 }


### PR DESCRIPTION
this adds gitea support and a very rough framework for adding other host types. it adds two config values for host (git.example.com, gitea.whatever.foo) and host_type(github, gitea).

I tested it very briefly just by egetting some binaries from my personal gitea deployment so could use some additional testing. 

example toml config:

```["user/repo"]
host = "git.example.com"
host_type = "gitea"
```

example command line arguments:

eget --host "git.example.com" --host-type gitea user/repo

closes #61 

